### PR TITLE
delete Front-end Week at (Repositórios da Front-End Brasil)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,4 @@ MIT &copy; Front-End Brasil
 * [Doe um livro](https://github.com/frontendbr/doe-um-livro)
 * [Poste mais!](https://github.com/frontendbr/poste-mais)
 * [Open Source](https://github.com/frontendbr/open-source)
-* [Front-end Week](https://github.com/frontendbr/frontendweek)
 * [Sugestões](https://github.com/frontendbr/sugestoes)


### PR DESCRIPTION
Tirei o Repositório Front-end Week mencionado no README.md na seção Repositórios da Front-End Brasil porque não existe.